### PR TITLE
Fix enzyme tests leaking into rtl tests

### DIFF
--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
@@ -16,16 +16,13 @@ describe('<SnackbarContent />', () => {
     classes = getClasses(<SnackbarContent message="message" />);
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<SnackbarContent message="conform?" />, () => ({
     classes,
     inheritComponent: Paper,
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   describe('prop: action', () => {
@@ -52,8 +49,8 @@ describe('<SnackbarContent />', () => {
   describe('prop: message', () => {
     it('should render the message', () => {
       const message = 'message prop text';
-      const { getAllByRole } = render(<SnackbarContent message={<span>{message}</span>} />);
-      expect(getAllByRole('alert')[1]).to.have.text(message);
+      const { getByRole } = render(<SnackbarContent message={<span>{message}</span>} />);
+      expect(getByRole('alert')).to.have.text(message);
     });
   });
 


### PR DESCRIPTION
Since `describeConformance` requires testing with `enzyme` anything rendered is only cleaned up until `after` which is after the full test suite. This means it leaks into anything rendered from react-testing-library. This was visible by 2 `alert` being present in the individual cases. `describeConformance` has a `after` option if it is used in tests with react-testing-library to prevent this.